### PR TITLE
Update test_nndct.py, use total-1 instead of  hardcoded 999

### DIFF
--- a/yolov7/yolov7/test_nndct.py
+++ b/yolov7/yolov7/test_nndct.py
@@ -231,7 +231,7 @@ def test(data,
         if model.dump_model:
             break
         if model.quant_mode == 'calib':
-            if batch_i == 999:
+            if batch_i == total-1:
                 break
 
     if not training:


### PR DESCRIPTION
The breaking condition of the loop was when batch_i = 999. Instead changed this to use total-1 so if the total was updated to lower or higher value (total specified total no of images to use) it would reflect and break the loop accordingly